### PR TITLE
#162948922 Article pagination

### DIFF
--- a/authors/apps/articles/tests/test_articles.py
+++ b/authors/apps/articles/tests/test_articles.py
@@ -99,8 +99,9 @@ class ArticleTestCase(APITestCase):
             format="json"
         )
         self.assertEqual(response.status_code, 200)
-        data = response.data
-        self.assertTrue(len(data) == 0)
+        self.assertIn('count', response.data)
+        self.assertIn('next', response.data)
+        self.assertIn('previous', response.data)
 
     def test_get_one_article(self):
         """

--- a/authors/apps/articles/views.py
+++ b/authors/apps/articles/views.py
@@ -23,6 +23,7 @@ from .renderers import ArticleJSONRenderer
 from .models import Article, Tags
 from .serializers import ArticleSerializer, TagSerializers
 from .messages import error_msgs, success_msg
+from authors.apps.core.pagination import PaginateContent
 
 
 class ArticleAPIView(generics.ListCreateAPIView):
@@ -62,16 +63,16 @@ class ArticleAPIView(generics.ListCreateAPIView):
         """
             GET /api/v1/articles/
         """
-        permission_classes = (AllowAny,)
-        queryset = self.get_queryset()
+        perform_pagination = PaginateContent()
+        objs_per_page = perform_pagination.paginate_queryset(self.queryset, request)
         serializer = ArticleSerializer(
-            queryset,
+            objs_per_page,
             context={
                 'request': request
             },
             many=True
         )
-        return Response(serializer.data, status=200)
+        return perform_pagination.get_paginated_response(serializer.data)
 
 
 class SpecificArticle(generics.RetrieveUpdateDestroyAPIView):

--- a/authors/apps/comments/models.py
+++ b/authors/apps/comments/models.py
@@ -19,3 +19,4 @@ class Comments(models.Model):
 
     def __str__(self):
         return str(self.author_profile)
+        

--- a/authors/apps/comments/serializers.py
+++ b/authors/apps/comments/serializers.py
@@ -1,5 +1,4 @@
 from django.contrib.contenttypes.models import ContentType
-
 from authors.apps.articles.serializers import ArticleSerializer
 from authors.apps.authentication.messages import statusmessage
 from authors.apps.authentication.serializers import UserSerializer
@@ -7,7 +6,6 @@ from authors.apps.like_dislike.models import LikeDislike
 from authors.apps.like_dislike.serializers import PreferenceSerializer
 from authors.apps.profiles.serializers import UserProfileSerializer
 from rest_framework import serializers
-
 from .models import Comments
 
 

--- a/authors/apps/comments/tests/test_comments.py
+++ b/authors/apps/comments/tests/test_comments.py
@@ -29,7 +29,6 @@ class CommentsTests(TestBaseCase):
         """
         Test if authenticated users can create comments
         """
-
         token = self.login_user()
         slug = self.create_article()
 
@@ -69,7 +68,9 @@ class CommentsTests(TestBaseCase):
             format='json',
         )
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        return response
+        self.assertIn('count', response.data)
+        self.assertIn('next', response.data)
+        self.assertIn('previous', response.data)
 
     def test_get_specific_comment(self):
         """

--- a/authors/apps/core/pagination.py
+++ b/authors/apps/core/pagination.py
@@ -1,0 +1,9 @@
+from rest_framework.pagination import PageNumberPagination
+
+
+class PaginateContent(PageNumberPagination):
+    """
+        Custom pagination class
+    """
+    page_size = 10
+    page_size_query_param = 'page_size'

--- a/authors/settings.py
+++ b/authors/settings.py
@@ -171,7 +171,7 @@ REST_FRAMEWORK = {
     ),
 
     'DEFAULT_PAGINATION_CLASS': 'rest_framework.pagination.PageNumberPagination',
-    'PAGE_SIZE': 2
+    'PAGE_SIZE': 10
 }
 
 # Django Rest Framework Jwt settings

--- a/authors/urls.py
+++ b/authors/urls.py
@@ -34,6 +34,7 @@ schema_view = get_schema_view(
 
 # urls
 urlpatterns = [
+
     path('admin/', admin.site.urls),
     path('api/v1/', include('authors.apps.like_dislike.urls',
                             namespace='likes')),
@@ -49,5 +50,4 @@ urlpatterns = [
     path('api/v1/', include('authors.apps.articles.urls')),
     path('api/v1/', include('authors.apps.rating.urls')),
     path('api/v1/', include('authors.apps.comments.urls')),
-    path('api/v1/', include('authors.apps.rating.urls')),
 ]


### PR DESCRIPTION
#### What does this PR do?
Has the functionality for the user to view paginated articles

#### Description of Task(s) to be completed?
* Users should be able to view a specific number of articles per page, 
* The user can also choose the number of articles they want to view per page.

#### How should this be manually tested?
* Pull the branch `git fetch origin ft-pagination-162948922:ft-pagination-162948922`
* Checkout to the branch `ft-pagination-162948922`
* Install requirements `pip3 install -r requirements.txt`
* Run the server `python3 manage.py runserver`
* Launch postman and get all articles by sending a GET request to `http://127.0.0.1:8000/api/v1/articles/` 
* This gets the default ten articles per page.
* Get paginated articles by sending a GET request to `http://127.0.0.1:8000/api/v1/articles/?page_size=5` 
* This gets five articles per page
* To get articles on the next page, send a GET request to `http://127.0.0.1:8000/api/v1/articles/?page=2&page_size=5`
*This gets 5 articles from the next page
* Get paginated comments by sending a GET request to `http://127.0.0.1:8000/api/v1/articles/<slug>/comments/?page_size=15` 
*This gets 15 comments related to that specific article
* To get comments on the next page, send a GET request to `http://127.0.0.1:8000/api/v1/articles/<slug>/comments/?page=2&page_size=15`
*This gets 15 comments from page 2

#### What are the relevant pivotal tracker stories?
[#162948922](https://www.pivotaltracker.com/story/show/162948922)
 